### PR TITLE
add HP color mode (smoothly transitions from green at 100% to yellow at 50% to red at 0%)

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -6,6 +6,7 @@ local L = LibStub("AceLocale-3.0"):NewLocale(addonName, "enUS", true)
 L["colorMode"] = "Color by: "
 L["optionClass"] = "Class"
 L["optionBlizzard"] = "Blizzard green"
+L["optionHP"] = "HP"
 L["optionCustom"] = "Custom"
 L["optionClassReaction"] = "Class / Reaction"
 L["optionReaction"] = "Reaction"

--- a/Modules/_shared_/HealthBarColor_Units_Basic.lua
+++ b/Modules/_shared_/HealthBarColor_Units_Basic.lua
@@ -3,6 +3,7 @@
   1 = class
   2 = blizzard green (has no effect when also playing with custom textures and will then just default to 0,1,0)
   3 = custom
+  4 = HP (smoothly transition from green at 100% to yellow at 50% to red at 0%)
 ]]
 local _, addonTable = ...
 local addon = addonTable.addon
@@ -28,6 +29,21 @@ for _, unit in pairs(units) do
     elseif dbObj.colorMode == 2 then
       hbc_unit.updateFullCallbacks["update_health_bar_color"] = function()
         hbc_unit:RestoreHealthBarToDefault()
+      end
+    elseif dbObj.colorMode == 4 then
+      hbc_unit.updateFullCallbacks["update_health_bar_color"] = function()
+        local hpPercentage = math.min(1.0, UnitHealth(hbc_unit.UnitId,false) / UnitHealthMax(hbc_unit.UnitId))
+        local r, g, b
+        if hpPercentage > 0.5 then
+          r = (1.0 - hpPercentage) * 2
+          g = 1.0
+        else
+          r = 1.0
+          g = hpPercentage * 2
+        end
+        b = 0
+        local hpBasedColor = CreateColor(r, g, b, 1.0)
+        hbc_unit:SetHealthBarToCustomColor(hpBasedColor, hpBasedColor)
       end
     else
       local startColor = CreateColor(dbObj.customColorStart.r, dbObj.customColorStart.g, dbObj.customColorStart.b, dbObj.customColorStart.a)

--- a/Modules/_shared_/HealthBarColor_Units_Extended.lua
+++ b/Modules/_shared_/HealthBarColor_Units_Extended.lua
@@ -6,6 +6,7 @@
   4 = custom
   5 = class/blizzard green (has no effect when also playing with custom textures and will then just default to 0,1,0)
   6 = blizzard green (has no effect when also playing with custom textures and will then just default to 0,1,0)
+  7 = HP (smoothly transition from green at 100% to yellow at 50% to red at 0%)
 ]]
 local _, addonTable = ...
 local addon = addonTable.addon
@@ -57,6 +58,21 @@ for _, unit in pairs(units) do
         else
           hbc_unit:RestoreHealthBarToDefault()
         end
+      end
+    elseif dbObj.colorMode == 7 then
+      hbc_unit.updateFullCallbacks["update_health_bar_color"] = function()
+        local hpPercentage = math.min(1.0, UnitHealth(hbc_unit.UnitId,false) / UnitHealthMax(hbc_unit.UnitId))
+        local r, g, b
+        if hpPercentage > 0.5 then
+          r = (1.0 - hpPercentage) * 2
+          g = 1.0
+        else
+          r = 1.0
+          g = hpPercentage * 2
+        end
+        b = 0
+        local hpBasedColor = CreateColor(r, g, b, 1.0)
+        hbc_unit:SetHealthBarToCustomColor(hpBasedColor, hpBasedColor)
       end
     else -- 6
       hbc_unit.updateFullCallbacks["update_health_bar_color"] = function()

--- a/Options/HealthBarsTabOptions.lua
+++ b/Options/HealthBarsTabOptions.lua
@@ -19,6 +19,7 @@ local basic_options =
   L["optionClass"],
   L["optionBlizzard"],
   L["optionCustom"],
+  L["optionHP"],
 }
 local basic_option_units
 if addonTable.isRetail then
@@ -43,11 +44,12 @@ end
 local extended_options =
 {
   L["optionClassReaction"],
-  L["optionReaction"] ,
+  L["optionReaction"],
   L["optionClassCustom"],
   L["optionCustom"],
   L["optionClassBlizzard"],
-  L["optionBlizzard"] ,
+  L["optionBlizzard"],
+  L["optionHP"],
 }
 local extended_option_units
 if addonTable.isVanilla then

--- a/UnitManager.lua
+++ b/UnitManager.lua
@@ -2,7 +2,7 @@ local _, addonTable = ...
 local addon = addonTable.addon
 local globalUnitVariables = addonTable.globalUnitVariables
 
-local hbc_units = 
+local hbc_units =
 {
   ["player"] = false,
   ["target"] = false,
@@ -71,15 +71,21 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
     if hbc_units[unit] then
       hbc_units[unit]:PowerUpdate()
     end
+  elseif event == "UNIT_HEALTH" then
+    if hbc_units[unit] then
+      hbc_units[unit]:FullUpdate()
+    end
   elseif event == "UPDATE_SHAPESHIFT_FORM" then
     hbc_units["player"]:PowerUpdate()
   end
 end)
 if addonTable.isVanilla then
   eventFrame:RegisterUnitEvent("UNIT_TARGET", "target")
+  eventFrame:RegisterUnitEvent("UNIT_HEALTH", "player", "pet", "target", "targettarget")
   eventFrame:RegisterUnitEvent("UNIT_POWER_UPDATE", "player", "pet", "target", "targettarget")
 else
   eventFrame:RegisterUnitEvent("UNIT_TARGET", "target", "focus")
+  eventFrame:RegisterUnitEvent("UNIT_HEALTH", "player", "pet", "target", "targettarget", "focus", "focustarget")
   eventFrame:RegisterUnitEvent("UNIT_POWER_UPDATE", "player", "pet", "target", "targettarget", "focus", "focustarget")
 end
 eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")


### PR DESCRIPTION
This is called "smooth color" in some other addons, but that naming scheme does not make it clear that the color is based on current HP percentage.